### PR TITLE
Clean the util in tests by renaming and using fold instead of isLeft checks.

### DIFF
--- a/test/pet-store-lite.test.ts
+++ b/test/pet-store-lite.test.ts
@@ -1,16 +1,17 @@
 import fs from "fs";
 import yaml from "js-yaml";
-import { lazy } from "./util";
+import { mapRightOrThrow } from "./util";
 import loas from "../src";
 
 test("highly condensed schema validates", () => {
-  const instance = yaml.load(
+  const loasSpec = yaml.load(
     fs.readFileSync("./test/pet-store-lite.loas3.yml").toString()
   );
-  const expanded = yaml.load(
+  const expandedSpecExpected = yaml.load(
     fs.readFileSync("./test/pet-store-lite.full.yml").toString()
   );
-  lazy(loas(instance), val => {
-    expect(val).toEqual(expanded);
+  const expandedSpec = loas(loasSpec);
+  mapRightOrThrow(expandedSpec, spec => {
+    expect(spec).toEqual(expandedSpecExpected);
   });
 });

--- a/test/pet-store.test.ts
+++ b/test/pet-store.test.ts
@@ -1,13 +1,14 @@
 import fs from "fs";
 import yaml from "js-yaml";
 import loas from "../src";
-import { lazy } from "./util";
+import { mapRightOrThrow } from "./util";
 
 test("processing on unlazy schema is a no-op", () => {
-  const instance = yaml.load(
+  const loasSpec = yaml.load(
     fs.readFileSync("./test/pet-store.yml").toString()
   );
-  lazy(loas(instance), val => {
-    expect(val).toEqual(instance);
+  const expandedSpecOrErrors = loas(loasSpec);
+  mapRightOrThrow(expandedSpecOrErrors, spec => {
+    expect(spec).toEqual(loasSpec);
   });
 });

--- a/test/slack.test.ts
+++ b/test/slack.test.ts
@@ -1,11 +1,12 @@
 import fs from "fs";
 import yaml from "js-yaml";
 import loas from "../src";
-import { lazy } from "./util";
+import { mapRightOrThrow } from "./util";
 
 test("slack in, slack out", () => {
-  const instance = yaml.load(fs.readFileSync("./test/slack.yml").toString());
-  lazy(loas(instance), val => {
-    expect(val).toEqual(instance);
+  const spec = yaml.load(fs.readFileSync("./test/slack.yml").toString());
+  const expandedSpecOrErrors = loas(spec);
+  mapRightOrThrow(expandedSpecOrErrors, spec => {
+    expect(spec).toEqual(spec);
   });
 });

--- a/test/stripe.test.ts
+++ b/test/stripe.test.ts
@@ -1,11 +1,12 @@
 import fs from "fs";
 import yaml from "js-yaml";
 import loas from "../src";
-import { lazy } from "./util";
+import { mapRightOrThrow } from "./util";
 
 test("stripe in, stripe out", () => {
-  const instance = yaml.load(fs.readFileSync("./test/stripe.yml").toString());
-  lazy(loas(instance), val => {
-    expect(val).toEqual(instance);
+  const spec = yaml.load(fs.readFileSync("./test/stripe.yml").toString());
+  const expandedSpecOrErrors = loas(spec);
+  mapRightOrThrow(expandedSpecOrErrors, val => {
+    expect(val).toEqual(spec);
   });
 });

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,4 +1,4 @@
-import { Either, fold, isLeft } from "fp-ts/lib/Either";
+import { Either, fold } from "fp-ts/lib/Either";
 import { ErrorObject } from "ajv";
 import { OpenAPIObject } from "../src/generated/full";
 

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,12 +1,12 @@
-import { Either, isLeft } from "fp-ts/lib/Either";
+import { Either, fold, isLeft } from "fp-ts/lib/Either";
 import { ErrorObject } from "ajv";
 import { OpenAPIObject } from "../src/generated/full";
-export const lazy = (
+
+export const mapRightOrThrow = (
   res: Either<ErrorObject[], OpenAPIObject>,
   f: (val: OpenAPIObject) => void
 ) => {
-  if (isLeft(res)) {
-    throw new Error(res.left.map(i => i.message).join("\n"));
-  }
-  return f(res.right);
+  return fold((errs: ErrorObject[]) => {
+    throw new Error(errs.map(i => i.message).join("\n"));
+  }, f)(res);
 };


### PR DESCRIPTION
`isLeft` and `isRight` are imperative, in my experience in FP it's better to avoid imperative clauses wherever possible and here it seems possible.