### PR TITLE
Bump the version to 0.1.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loas3",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "description": "OpenAPI 3.0.0 for lazy people",
   "main": "dist/index.js",
   "repository": "https://github.com/unmock/loas3",


### PR DESCRIPTION
- Breaks compatibility with previous versions as import paths have no `src` so bump the minor version.
- [Full compare](https://github.com/unmock/loas3/compare/v0.0.5...version-0.1.0)