### PR TITLE
Add note about Git LFS to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ npx loas3 /path/to/lazy-spec.yaml
 
 ## Development
 
+Before starting, make sure that you have [Git Large File Storage (LFS)](https://git-lfs.github.com/) installed. We use this to store the API schemas and it's required for the tests to pass locally.
+
 Install dependencies and run tests:
 
 ```bash


### PR DESCRIPTION
Ran into issues with tests passing in my local environment while updating packages. After a conversation with @mikesol, we realized that the issue was that I didn't have Git LFS installed. So I added a note the Development section of the README.